### PR TITLE
Add a `aspell` as a default entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,3 +24,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends build-essential
     && make install \
 
   && rm -rf /aspell* /var/lib/apt/lists/*
+ENTRYPOINT ["aspell"]


### PR DESCRIPTION
to allow this to be run in an easier way